### PR TITLE
Give user the option to not download the normals

### DIFF
--- a/nyuv2/nyuv2.py
+++ b/nyuv2/nyuv2.py
@@ -158,9 +158,10 @@ class NYUv2(Dataset):
         """
         try:
             for split in ["train", "test"]:
-                for type_ in [a for a, b in zip(["rgb", "seg13", "sn", "depth"],
-                                                [self.rgb_transform, self.seg_transform, self.sn_transform, self.depth_transform])
-                             if b is not None]:
+                for part, transform in zip(["rgb", "seg13", "sn", "depth"],
+                                           [self.rgb_transform, self.seg_transform, self.sn_transform, self.depth_transform]):
+                    if transform is None:
+                        continue
                     path = os.path.join(self.root, f"{split}_{type_}")
                     if not os.path.exists(path):
                         raise FileNotFoundError("Missing Folder")

--- a/nyuv2/nyuv2.py
+++ b/nyuv2/nyuv2.py
@@ -158,7 +158,9 @@ class NYUv2(Dataset):
         """
         try:
             for split in ["train", "test"]:
-                for type_ in ["rgb", "seg13", "sn", "depth"]:
+                for type_ in [a for a, b in zip(["rgb", "seg13", "sn", "depth"],
+                                                [self.rgb_transform, self.seg_transform, self.sn_transform, self.depth_transform])
+                             if b is not None]:
                     path = os.path.join(self.root, f"{split}_{type_}")
                     if not os.path.exists(path):
                         raise FileNotFoundError("Missing Folder")

--- a/nyuv2/nyuv2.py
+++ b/nyuv2/nyuv2.py
@@ -167,10 +167,14 @@ class NYUv2(Dataset):
     def download(self):
         if self._check_exists():
             return
-        download_rgb(self.root)
-        download_seg(self.root)
-        download_sn(self.root)
-        download_depth(self.root)
+        if self.rgb_transform is not None:
+            download_rgb(self.root)
+        if self.seg_transform is not None:
+            download_seg(self.root)
+        if self.sn_transform is not None:
+            download_sn(self.root)
+        if self.depth_transform is not None:
+            download_depth(self.root)
         print("Done!")
 
 

--- a/nyuv2/nyuv2.py
+++ b/nyuv2/nyuv2.py
@@ -45,6 +45,7 @@ class NYUv2(Dataset):
         root: str,
         train: bool = True,
         download: bool = False,
+        download_all: bool = True,
         rgb_transform=None,
         seg_transform=None,
         sn_transform=None,
@@ -76,6 +77,7 @@ class NYUv2(Dataset):
         self.train = train
         self._split = "train" if train else "test"
 
+        self.download_all = download_all
         if download:
             self.download()
 
@@ -167,13 +169,13 @@ class NYUv2(Dataset):
     def download(self):
         if self._check_exists():
             return
-        if self.rgb_transform is not None:
+        if self.rgb_transform is not None or self.download_all:
             download_rgb(self.root)
-        if self.seg_transform is not None:
+        if self.seg_transform is not None or self.download_all:
             download_seg(self.root)
-        if self.sn_transform is not None:
+        if self.sn_transform is not None or self.download_all:
             download_sn(self.root)
-        if self.depth_transform is not None:
+        if self.depth_transform is not None or self.download_all:
             download_depth(self.root)
         print("Done!")
 


### PR DESCRIPTION
By setting `download_all` to `False` and setting `sn_transform` to `None` the user can disable the download of normals.